### PR TITLE
Missing features

### DIFF
--- a/AutoFixture.IdGenerator.pas
+++ b/AutoFixture.IdGenerator.pas
@@ -14,7 +14,7 @@ private
   FId : Integer;
 public
   procedure SetStartValue(AStartId: Integer);
-  function getValue(aPropertyName: String; aType: TRttiType): TValue;
+  function getValue(aPropertyName: String; aType: TRttiType; AReferenceDepth: integer = -1): TValue;
   constructor Create;
 end;
 
@@ -22,7 +22,7 @@ TidGeneratorAnyType = class(TInterfacedObject, IValueGenerator)
 private
   FIdDict: TDictionary<TRttiType, Integer>;
 public
-  function getValue(aPropertyName: String; aType: TRttiType): TValue;
+  function getValue(aPropertyName: String; aType: TRttiType; AReferenceDepth: integer = -1): TValue;
   constructor Create;
 end;
 
@@ -37,7 +37,7 @@ begin
   FId := 1;
 end;
 
-function TIdGenerator.getValue(APropertyName: String; AType: TRttiType): TValue;
+function TIdGenerator.getValue(APropertyName: String; AType: TRttiType; AReferenceDepth: integer = -1): TValue;
 var
   vName: String;
 begin
@@ -62,7 +62,7 @@ begin
   FIdDict := TDictionary<TRttiType, Integer>.Create;
 end;
 
-function TidGeneratorAnyType.getValue(aPropertyName: String; aType: TRttiType): TValue;
+function TidGeneratorAnyType.getValue(aPropertyName: String; aType: TRttiType; AReferenceDepth: integer = -1): TValue;
 var
   vId: Integer;
 begin

--- a/AutoFixture.pas
+++ b/AutoFixture.pas
@@ -20,7 +20,7 @@ TTypeList = class
     function GetRandomType: TRttiType;
   public
     constructor Create(AType: TRttiType);
-    function Orto<T>: TTypeList;
+    function OrTo<T>: TTypeList;
 end;
 
 TAutoFixture = class;
@@ -38,23 +38,32 @@ private
   FBindtypeDict: TDictionary<TRttiType, TTypeList>;
   FConfigurationDict: TDictionary<TRttiType, IObjectGenerator>;
 
+  procedure setObjectProperties(AType: TRttiType; AObject: TObject; AReferenceDepth: Integer);
+  procedure HandleCollection(ACollectionItemType: TRttiType);
+
+  // Deprecated methods!
+//  function NewInterfaceList<T: IInterface>: TList<T>; overload;
+//  function NewInterfaceList<T: IInterface>(AReferenceDepth: Integer): TList<T>; overload;
+//  function NewObject<T: Class>: T; overload;
+//  function NewInterface<T: IInterface>: T; overload;
+//  function NewInterface<T: IInterface>(AReferenceDepth: Integer): T; overload;
+
 public
   constructor Create;
   destructor Destroy; override;
-  function New<T: Class>: T; overload;
-  function New<T: Class>(AReferenceDepth: Integer): T; overload;
-  function NewInterface<T: IInterface>: T; overload;
-  function NewInterface<T: IInterface>(AReferenceDepth: Integer): T; overload;
-{TODO -ojehyk -cGeneral : Handle record types}
+  function New<T: Class>(AReferenceDepth: Integer; APropertyName: String = ''): T; overload;
+  function New<T>(APropertyName: String = ''): T; overload;
+
+  {TODO -ojehyk -cGeneral : Handle record types}
 //  function NewRecord<T: Record>: T; overload;
 //  function NewRecord<T: record>(AReferenceDepth: Integer): T; overload;
 
-  function NewList<T: Class>(AOwnsObjects: Boolean = True): TObjectList<T>; overload;
-  function NewList<T: Class>(AReferenceDepth: Integer; AOwnsObjects: Boolean = True): TObjectList<T>; overload;
-  function NewInterfaceList<T: IInterface>: TList<T>; overload;
-  function NewInterfaceList<T: IInterface>(AReferenceDepth: Integer): TList<T>; overload;
-  function NewValue<T>(APropertyName: String = ''): T; overload;
-  function NewValueList<T>(APropertyName: String = ''): TList<T>;
+  function NewObjectList<T: Class>(AOwnsObjects: Boolean = True): TObjectList<T>; overload;
+  function NewObjectList<T: Class>(AReferenceDepth: Integer; AOwnsObjects: Boolean = True): TObjectList<T>; overload;
+  function NewList<T>(APropertyName: String = ''): TList<T>;
+
+  procedure AddManyTo<T: Class>(var AList: T; ANumberOfElements: Integer=0);
+  procedure AddManyToArray<T>(var AArray: TArray<T>; ANumberOfElements: Integer=0);
 
   procedure Inject<T>(aValue: T); overload;
   procedure Inject<T>(aDelegate: TInjectNameDelegate<T>); overload;
@@ -63,14 +72,15 @@ public
   function DMock<T>(): Delphi.Mocks.TMock<T>;
   function SMock<T>(): Spring.Mocking.Mock<T>;
 
-  function Configure<T: Class>: TBaseConfig<T>;
-  function Build<T: Class>: TBaseConfig<T>;
+  function Configure<T: Class>: TObjectConfig<T>;
+  function Build<T: Class>: TObjectConfig<T>;
 
-  function getValue(aPropertyName: String; aType: TRttiType): TValue; overload;
-  function getObject(AType: TRttiType): TObject; overload;
-  function getObject(AType: TRttiType; AReferenceDepth: Integer): TObject; Overload;
+  function GetValue(aPropertyName: String; aType: TRttiType): TValue; overload;
+  function GetValue(aPropertyName: String; aType: TRttiType; AReferenceDepth: Integer): TValue; overload;
+  //function getObject(AType: TRttiType): TObject; overload;
+  function GetObject(AType: TRttiType; AReferenceDepth: Integer = -1): TObject;
 
-  procedure CallMethod(AOnObject: TObject; vMethod: TRttiMethod);
+  function CallMethod(AOnObject: TObject; vMethod: TRttiMethod; AReferenceDepth: Integer = -1): TValue;
   function RegisterType<T, TBind>: TTypeList;
   function ResolveType(ARttiType: TRttiType): TRttiType;
   function Fixture: TAutofixture;
@@ -84,7 +94,7 @@ protected
 public
   constructor Create(AAutoFixture: TAutoFixture);
   Function Fixture: TAutoFixture;
-  function getValue(aPropertyName: String; aType: TRttiType): TValue;
+  function getValue(aPropertyName: String; aType: TRttiType; AReferenceDepth: integer = -1): TValue;
   function getObject(AType: TRttiType; AReferenceDepth: Integer): TObject;
 end;
 
@@ -92,29 +102,80 @@ end;
 implementation
 
 uses SysUtils,
-  AutoFixture.IdGenerator;
+  AutoFixture.IdGenerator,
+  Spring;
 
 { TAutoFixture }
-function TAutoFixture.Build<T>: TBaseConfig<T>;
+procedure TAutoFixture.AddManyTo<T>(var AList: T; ANumberOfElements: Integer=0);
 var
+  i: Integer;
   ctx: TRttiContext;
   vType: TRttiType;
-  vGenerator: IObjectGenerator;
-  vEncapsulatedFixture: IObjectGenerator;
+  vMethod: TRttiMethod;
+  vParams: TArray<TRttiParameter>;
+  vParam: TRttiParameter;
+  vValueList: TArray<TValue>;
 begin
+  if ANumberOfElements <= 0 then begin
+    ANumberOfElements := FSetup.CollectionSize;
+  end;
+
   ctx := TRttiContext.Create;
   vType := ctx.GetType(TypeInfo(T));
 
-  if FConfigurationDict.TryGetValue(vType, vGenerator) then begin
-    Result := TBaseConfig<T>.Create(FSetup, vGenerator);
-  end
-  else begin
-    vEncapsulatedFixture := TEncapsulatedAutoFixture.Create(Self);
-    Result := TBaseConfig<T>.Create(FSetup, vEncapsulatedFixture);
+  // Find the "Add" method.
+  for vMethod in vType.GetMethods do begin
+    if (AnsiUpperCase(vMethod.Name) = 'ADD') then begin
+      vParams := vMethod.GetParameters;
+
+      if Length(vParams) = 1 then begin
+        vParam := vParams[0];
+        setLength(vValueList, 1);
+
+        for i := 1 to ANumberOfElements do begin
+          vValueList[0] := getValue('', vParam.ParamType);
+          vMethod.Invoke(AList, vValueList);
+        end;
+
+        break;
+      end
+      else if (Length(vParams) = 0) and (vMethod.ReturnType <> nil) then begin
+        setLength(vValueList, 0);
+
+        for i := 1 to ANumberOfElements do begin
+          vMethod.Invoke(AList, vValueList);
+        end;
+      end;
+    end;
   end;
 end;
 
-function TAutoFixture.Configure<T>: TBaseConfig<T>;
+procedure TAutoFixture.AddManyToArray<T>(var AArray: TArray<T>; ANumberOfElements: Integer=0);
+var
+  ctx: TRttiContext;
+  vType: TRttiType;
+  i: Integer;
+  vValue: TValue;
+  vActual: T;
+begin
+  ctx := TRttiContext.Create;
+  vType := ctx.GetType(TypeInfo(T));
+
+  if ANumberOfElements <= 0 then begin
+    ANumberOfElements := FSetup.CollectionSize;
+  end;
+
+  SetLength(AArray, Length(AArray) + ANumberOfElements);
+
+  for i := Length(AArray) - ANumberOfElements to Length(AArray) - 1 do begin
+    vValue := getValue('', vType);
+    if vValue.TryAsType(vActual) then begin
+      AArray[i] := vActual;
+    end;
+  end;
+end;
+
+function TAutoFixture.Build<T>: TObjectConfig<T>;
 var
   ctx: TRttiContext;
   vType: TRttiType;
@@ -125,14 +186,36 @@ begin
   vType := ctx.GetType(TypeInfo(T));
 
   if FConfigurationDict.TryGetValue(vType, vGenerator) then begin
-    Result := vGenerator as TBaseConfig<T>;
+    Result := TObjectConfig<T>.Create(FSetup, vGenerator);
   end
   else begin
     vEncapsulatedFixture := TEncapsulatedAutoFixture.Create(Self);
-    vGenerator := TBaseConfig<T>.Create(FSetup, vEncapsulatedFixture);
-    Result := TBaseConfig<T>(vGenerator);
+    Result := TObjectConfig<T>.Create(FSetup, vEncapsulatedFixture);
+  end;
+end;
+
+function TAutoFixture.Configure<T>: TObjectConfig<T>;
+var
+  ctx: TRttiContext;
+  vType: TRttiType;
+  vGenerator: IObjectGenerator;
+  vEncapsulatedFixture: IObjectGenerator;
+begin
+  ctx := TRttiContext.Create;
+  vType := ctx.GetType(TypeInfo(T));
+
+  if FConfigurationDict.TryGetValue(vType, vGenerator) then begin
+    if not (vGenerator is TObjectConfig<T>) then begin
+      vGenerator := TObjectConfig<T>.Create(FSetup, vGenerator);
+      FConfigurationDict[vType] := vGenerator;
+    end;
+  end
+  else begin
+    vEncapsulatedFixture := TEncapsulatedAutoFixture.Create(Self);
+    vGenerator := TObjectConfig<T>.Create(FSetup, vEncapsulatedFixture);
     FConfigurationDict.Add(vType, vGenerator);
   end;
+  Result := TObjectConfig<T>(vGenerator);
 end;
 
 constructor TAutoFixture.Create;
@@ -193,22 +276,65 @@ begin
   Result := Self;
 end;
 
-function TAutoFixture.getObject(AType: TRttiType): TObject;
+{$WARN UNSAFE_CAST OFF}
+procedure TAutoFixture.setObjectProperties(AType: TRttiType; AObject: TObject; AReferenceDepth: Integer);
+var
+  vProperty: TRttiProperty;
+  vValue: TValue;
+  vGenerator: IObjectGenerator;
 begin
-  Result := Self.getObject(AType, Setup.ReferenceDepth);
+  // Check if there is a configuration for this object type
+  if FConfigurationDict.TryGetValue(AType, vGenerator) then begin
+    // Loop through and set properties using the generator found
+    for vProperty in AType.GetProperties do
+    begin
+      if vProperty.IsWritable then
+      begin
+        // Try to set property value
+        vValue := vGenerator.getValue(vProperty.Name, vProperty.PropertyType, AReferenceDepth);
+
+        if not vValue.IsEmpty then
+        begin
+          vProperty.SetValue(Pointer(AObject), vValue);
+        end;
+      end;
+    end;
+  end
+  else begin
+    // Loop through and set properties using Autofixture
+    for vProperty in AType.GetProperties do
+    begin
+      if vProperty.IsWritable then
+      begin
+        // Try to set property value
+        vValue := getValue(vProperty.Name, vProperty.PropertyType, AReferenceDepth);
+        if not vValue.IsEmpty then
+        begin
+          vProperty.SetValue(Pointer(AObject), vValue);
+        end;
+      end;
+    end;
+  end;
 end;
 
-function TAutoFixture.getObject(AType: TRttiType; AReferenceDepth: Integer): TObject;
+function TAutoFixture.GetObject(AType: TRttiType; AReferenceDepth: Integer = -1): TObject;
 var
   vMethod, vConstructor, vAddMethod: TRttiMethod;
   vParameterList: TArray<TRttiParameter>;
-  vProperty: TRttiProperty;
   vField: TRttiField;
   vValue: TValue;
   i: Integer;
   vCollectionDetected: Boolean;
   vConfig: IObjectGenerator;
 begin
+  if AReferenceDepth = -1 then begin
+    AReferenceDepth := Setup.ReferenceDepth
+  end
+  else if AReferenceDepth = 0 then begin
+    Result := nil;
+    Exit;
+  end;
+
   // Lookup type bindings
   AType := ResolveType(AType);
 
@@ -218,19 +344,33 @@ begin
   end
   else begin
     Result := AType.AsInstance.MetaclassType.Create;
-    vAddMethod := nil;
 
-    // Find constructor method
+    // Find methods
     vConstructor := nil;
+    vAddMethod := nil;
 
     if FSetup.ConstructorSearch = TConstructorSearch.csSimplest then begin
       // Find simplest constructor deklareret i klassen
       for vMethod in AType.GetMethods do begin
         if vMethod.IsConstructor then begin
           if Assigned(vConstructor) then begin
-            // Find simplest constructor
-            if Length(vMethod.GetParameters()) < Length(vConstructor.GetParameters()) then begin
-              vConstructor := vMethod;
+            // don't shift to parent class constructor once class constructor found
+            if vMethod.Parent = AType then begin
+              if vConstructor.Parent = AType then begin
+                if Length(vMethod.GetParameters()) < Length(vConstructor.GetParameters()) then begin
+                  vConstructor := vMethod;
+                end;
+              end
+              else begin
+                vConstructor := vMethod;
+              end;
+            end
+            else begin
+              if vConstructor.Parent <> AType then begin
+                if Length(vMethod.GetParameters()) < Length(vConstructor.GetParameters()) then begin
+                  vConstructor := vMethod;
+                end;
+              end;
             end;
           end
           else begin
@@ -238,7 +378,14 @@ begin
           end;
         end
         else if vMethod.Name = 'Add' then begin
-          vAddMethod := vMethod;
+          if Assigned(vAddMethod) then begin
+            if (vMethod.Parent = AType) and (vAddMethod.Parent <> AType) then begin
+              vAddMethod := vMethod;
+            end;
+          end
+          else begin
+            vAddMethod := vMethod;
+          end;
         end;
       end;
     end
@@ -254,6 +401,17 @@ begin
           else begin
             vConstructor := vMethod;
           end;
+        end
+        else if vMethod.Name = 'Add' then begin
+          vAddMethod := vMethod;
+        end;
+      end;
+    end
+    else begin
+      // Find only add method
+      for vMethod in AType.GetDeclaredMethods do begin
+        if vMethod.Name = 'Add' then begin
+          vAddMethod := vMethod;
         end;
       end;
     end;
@@ -267,11 +425,30 @@ begin
       vParameterList := vAddMethod.GetParameters;
 
       if Setup.AutoDetectList then begin
-        if Length(vParameterList) = 1 then begin
+        if Length(vParameterList) <= 1 then begin
           vCollectionDetected := True;
 
-          for i := 1 to Setup.CollectionSize do begin
-            CallMethod(Result, vAddMethod);
+          if Length(vParameterList) = 1 then begin
+            // Some type of list with an add method taking one parameter
+            for i := 1 to Setup.CollectionSize do begin
+              CallMethod(Result, vAddMethod, AReferenceDepth);
+            end;
+          end
+          else begin
+            // Probably some kind of collection with an add method returning a TCollectionItem
+            if Assigned(vAddMethod.ReturnType) and (vAddMethod.ReturnType.TypeKind = tkClass) then begin
+              for i := 1 to Setup.CollectionSize do begin
+                HandleCollection(vAddMethod.ReturnType);
+                vValue := CallMethod(Result, vAddMethod, AReferenceDepth);
+                if not vValue.IsEmpty then begin
+                  SetObjectProperties(vAddMethod.ReturnType, vValue.AsObject, AReferenceDepth);
+                end;
+              end;
+            end
+            else begin
+              // Nope, not a TCollection anyway
+              vCollectionDetected := False;
+            end;
           end;
         end;
       end
@@ -281,7 +458,7 @@ begin
             vCollectionDetected := True;
 
             for i := 1 to Setup.CollectionSize do begin
-              CallMethod(Result, vAddMethod);
+              CallMethod(Result, vAddMethod, AReferenceDepth);
             end;
           end;
         end;
@@ -290,69 +467,60 @@ begin
 
     if not vCollectionDetected then begin
       // Loop through and set fields
-      for vField in AType.GetFields do begin
-        if vField.Name <> 'FRefCount' then begin
-          // Try to set value
-          vValue := getValue(vField.Name, vField.FieldType);
 
-          if not vValue.IsEmpty then begin
-            vField.SetValue(Pointer(Result), vValue);
-          end
-          else begin
-            if Assigned(vField.FieldType) and (vField.FieldType.TypeKind = tkClass) then begin
-              if AReferenceDepth > 1 then begin
-                vValue := TValue.From(getObject(vField.FieldType, AReferenceDepth - 1));
-                vField.SetValue(Pointer(Result), vValue);
-              end;
-            end;
-          end;
-        end;
-      end;
-
-      // Loop through and set properties
-      for vProperty in AType.GetProperties do begin
-        if vProperty.IsWritable then begin
-          // Try to set property value
-          vValue := getValue(vProperty.Name, vProperty.PropertyType);
-
-          if not vValue.IsEmpty then begin
-            vProperty.SetValue(Pointer(Result), vValue);
-          end
-          else begin
-            if vProperty.PropertyType.TypeKind = tkClass then begin
-              if AReferenceDepth > 1 then begin
-                vValue := TValue.From(getObject(vProperty.PropertyType, AReferenceDepth - 1));
-                vProperty.SetValue(Pointer(Result), vValue);
-              end;
-            end;
-          end;
-        end;
-      end;
+//      for vField in AType.GetFields do begin
+//        if vField.Name <> 'FRefCount' then begin
+//          // Try to set value
+//          vValue := getValue(vField.Name, vField.FieldType, AReferenceDepth -1);
+//
+//          if not vValue.IsEmpty then begin
+//            vField.SetValue(Pointer(Result), vValue);
+//          end
+//          else begin
+//            if Assigned(vField.FieldType) and (vField.FieldType.TypeKind = tkClass) then begin
+//              if AReferenceDepth > 1 then begin
+//                vValue := TValue.From(getObject(vField.FieldType, AReferenceDepth - 1));
+//                vField.SetValue(Pointer(Result), vValue);
+//              end;
+//            end;
+//          end;
+//        end;
+//      end;
+      setObjectProperties(AType, Result, AReferenceDepth);
     end;
   end;
 end;
 
-procedure TAutoFixture.CallMethod(AOnObject: TObject; vMethod: TRttiMethod);
+function TAutoFixture.getValue(aPropertyName: String; aType: TRttiType): TValue;
+begin
+  Result := getValue(APropertyName, AType, Setup.ReferenceDepth);
+end;
+
+function TAutoFixture.CallMethod(AOnObject: TObject; vMethod: TRttiMethod; AReferenceDepth: Integer = -1): TValue;
 var
   vValueList: TList<TValue>;
   vParam: TRttiParameter;
   vValue: TValue;
 begin
+  if AReferenceDepth = -1 then begin
+    AReferenceDepth := FSetup.ReferenceDepth;
+  end;
+
   vValueList := TList<TValue>.Create;
   try
     for vParam in vMethod.GetParameters do
     begin
-      vValue := getValue(vParam.Name, vParam.ParamType);
+      vValue := getValue(vParam.Name, vParam.ParamType, AReferenceDepth);
       vValueList.Add(vValue);
     end;
-    vMethod.Invoke(AOnObject, vValueList.ToArray);
+    Result := vMethod.Invoke(AOnObject, vValueList.ToArray);
   finally
     FreeAndNil(vValueList);
   end;
 end;
 
 
-function TAutoFixture.getValue(APropertyName: String; AType: TRttiType): TValue;
+function TAutoFixture.getValue(APropertyName: String; AType: TRttiType; AReferenceDepth: Integer): TValue;
 var vGenerator: IValueGenerator;
   vValue: TValue;
 begin
@@ -362,109 +530,130 @@ begin
     AType := ResolveType(AType);
 
     for vGenerator in FGenerators do begin
-      vValue := vGenerator.getValue(aPropertyName, aType);
+      vValue := vGenerator.getValue(aPropertyName, aType, AReferenceDepth);
 
       if not vValue.IsEmpty then begin
         Result := vValue;
       end;
     end;
 
-    if vValue.IsEmpty then begin
+    if Result.IsEmpty then begin
       if AType.TypeKind = tkClass then begin
-        Result := TValue.From(getObject(AType));
+        Result := TValue.From(getObject(AType, AReferenceDepth));
       end;
     end;
   end;
 end;
 
-function TAutoFixture.NewValue<T>(APropertyName: String): T;
+procedure TAutoFixture.HandleCollection(ACollectionItemType: TRttiType);
+var
+  vGenerator: IObjectGenerator;
+  vCollectionItemGenerator: TCollectionItemGenerator;
+begin
+  if FConfigurationDict.TryGetValue(ACollectionItemType, vGenerator) then begin
+    // there is already a configured item for this element - best thing to do is to add a collectionItem handler on top
+    if not (vGenerator is TCollectionItemGenerator) then begin
+      FConfigurationDict[ACollectionItemType] := TCollectionItemGenerator.Create(ACollectionItemType, vGenerator);
+    end;
+  end
+  else begin
+    vCollectionItemGenerator := TCollectionItemGenerator.Create(ACollectionItemType, TEncapsulatedAutoFixture.Create(Self));
+    FConfigurationDict.Add(ACollectionItemType, vCollectionItemGenerator);
+  end;
+end;
+
+function TAutoFixture.New<T>(APropertyName: String): T;
 var ctx: TRttiContext;
   vValue: TValue;
+  vType: TRttiType;
 begin
   ctx := TRttiContext.Create;
-  vValue := getValue(APropertyName, ctx.getType(TypeInfo(T)));
+  vType := ctx.getType(TypeInfo(T));
+  vValue := getValue(APropertyName, vType);
 
   if vValue.isEmpty then begin
     Result := Default(T);
   end
   else begin
-    Result := vValue.AsType<T>;
+    if not vValue.TryAsType(Result) then begin
+      result := vValue.AsType<T>;
+    end;
   end;
 end;
 
-function TAutoFixture.NewInterface<T>: T;
-begin
-  Result := NewInterface<T>(Setup.ReferenceDepth);
-end;
+//function TAutoFixture.NewInterface<T>: T;
+//begin
+//  Result := NewInterface<T>(Setup.ReferenceDepth);
+//end;
 
-function TAutoFixture.NewInterface<T>(AReferenceDepth: Integer): T;
-var ctx: TRttiContext;
-  vType: TRttiType;
-  vValue: TValue;
-  vObj: TObject;
-  vObjCast: TInterfacedObject;
-  vIObj: IInterface;
-  vClassName: String;
-begin
-  Result := nil;
-  ctx := TRttiContext.Create;
-  vValue := getValue('', ctx.getType(TypeInfo(T)));
+//function TAutoFixture.NewInterface<T>(AReferenceDepth: Integer): T;
+//var ctx: TRttiContext;
+//  vType: TRttiType;
+//  vValue: TValue;
+//  vObj: TObject;
+//  vObjCast: TInterfacedObject;
+//  vIObj: IInterface;
+//  vClassName: String;
+//begin
+//  Result := nil;
+//  ctx := TRttiContext.Create;
+//  vValue := getValue('', ctx.getType(TypeInfo(T)));
+//
+//  if vValue.IsEmpty then begin
+//    vType := ctx.GetType(TypeInfo(T));
+//    vObj := getObject(vType, AReferenceDepth);
+//  end
+//  else begin
+//    vObj := vValue.AsObject;
+//  end;
+//
+//  vClassName := vObj.ClassName;
+//
+//  vObjCast := vObj as TInterfacedObject;
+//  vIObj := IInterface(vObjCast);
+//  Result := T(vIObj);
+//
+//  if (vObj is TInterfacedObject) and (vClassName<>'') then begin
+//    vObjCast := TInterfacedObject(vObj);
+//    vIObj := IInterface(vObjCast);
+//    Result := T(vIObj);
+//  end;
+//
+//  ctx.Free;
+//end;
 
-  if vValue.IsEmpty then begin
-    vType := ctx.GetType(TypeInfo(T));
-    vObj := getObject(vType, AReferenceDepth);
-  end
-  else begin
-    vObj := vValue.AsObject;
-  end;
-
-  vClassName := vObj.ClassName;
-
-  vObjCast := vObj as TInterfacedObject;
-  vIObj := IInterface(vObjCast);
-  Result := T(vIObj);
-
-  if (vObj is TInterfacedObject) and (vClassName<>'') then begin
-    vObjCast := TInterfacedObject(vObj);
-    vIObj := IInterface(vObjCast);
-    Result := T(vIObj);
-  end;
-
-  ctx.Free;
-end;
-
-function TAutoFixture.NewValueList<T>(APropertyName: String): TList<T>;
+function TAutoFixture.NewList<T>(APropertyName: String): TList<T>;
 var
   i: Integer;
 begin
   Result := TList<T>.Create;
   for i := 1 to Fsetup.CollectionSize do begin
-    Result.Add(NewValue<T>(APropertyName));
+    Result.Add(New<T>(APropertyName));
   end;
 end;
 
 
-function TAutoFixture.NewInterfaceList<T>: TList<T>;
-var
-  i: Integer;
-begin
-  Result := TList<T>.Create;
-  for i := 1 to Fsetup.CollectionSize do begin
-    Result.Add(NewInterFace<T>())
-  end;
-end;
+//function TAutoFixture.NewInterfaceList<T>: TList<T>;
+//var
+//  i: Integer;
+//begin
+//  Result := TList<T>.Create;
+//  for i := 1 to Fsetup.CollectionSize do begin
+//    Result.Add(NewInterFace<T>())
+//  end;
+//end;
 
-function TAutoFixture.NewInterfaceList<T>(AReferenceDepth: Integer): TList<T>;
-var
-  i: Integer;
-begin
-  Result := TList<T>.Create;
-  for i := 1 to Fsetup.CollectionSize do begin
-    Result.Add(NewInterFace<T>(AReferenceDepth))
-  end;
-end;
+//function TAutoFixture.NewInterfaceList<T>(AReferenceDepth: Integer): TList<T>;
+//var
+//  i: Integer;
+//begin
+//  Result := TList<T>.Create;
+//  for i := 1 to Fsetup.CollectionSize do begin
+//    Result.Add(NewInterFace<T>(AReferenceDepth))
+//  end;
+//end;
 
-function TAutoFixture.NewList<T>(AOwnsObjects: Boolean): TObjectList<T>;
+function TAutoFixture.NewObjectList<T>(AOwnsObjects: Boolean): TObjectList<T>;
 var
   i: Integer;
 begin
@@ -474,7 +663,7 @@ begin
   end;
 end;
 
-function TAutoFixture.NewList<T>(AReferenceDepth: Integer; AOwnsObjects: Boolean): TObjectList<T>;
+function TAutoFixture.NewObjectList<T>(AReferenceDepth: Integer; AOwnsObjects: Boolean): TObjectList<T>;
 var
   i: Integer;
 begin
@@ -565,7 +754,7 @@ begin
   end;
 end;
 
-function TTypeList.Orto<T>: TTypeList;
+function TTypeList.OrTo<T>: TTypeList;
 var ctx: TRttiContext;
 begin
   ctx := TRttiContext.Create;
@@ -589,24 +778,24 @@ begin
   Result := FAutoFixture.GetObject(AType, AReferenceDepth);
 end;
 
-function TEncapsulatedAutoFixture.getValue(APropertyName: String; AType: TRttiType): TValue;
+function TEncapsulatedAutoFixture.getValue(APropertyName: String; AType: TRttiType; AReferenceDepth: integer = -1): TValue;
 begin
-  Result := FAutoFixture.getValue(APropertyName, AType);
+  Result := FAutoFixture.getValue(APropertyName, AType, AReferenceDepth);
 end;
 
-function TAutoFixture.New<T>: T;
-begin
-  Result := Self.New<T>(Setup.ReferenceDepth);
-end;
+//function TAutoFixture.NewObject<T>: T;
+//begin
+//  Result := Self.New<T>(Setup.ReferenceDepth);
+//end;
 
-function TAutoFixture.New<T>(AReferenceDepth: Integer): T;
+function TAutoFixture.New<T>(AReferenceDepth: Integer; APropertyName: String = ''): T;
 var ctx: TRttiContext;
   vType: TRttiType;
   vValue: TValue;
   vObj: TObject;
 begin
   ctx := TRttiContext.Create;
-  vValue := getValue('', ctx.getType(TypeInfo(T)));
+  vValue := getValue(APropertyName, ctx.getType(TypeInfo(T)));
 
   if vValue.IsEmpty then begin
     vType := ctx.GetType(TypeInfo(T));

--- a/AutoFixture.pas
+++ b/AutoFixture.pas
@@ -55,7 +55,8 @@ public
   function NewInterfaceList<T: IInterface>(AReferenceDepth: Integer): TList<T>; overload;
 
   function getValue(aPropertyName: String; aType: TRttiType): TValue; overload;
-  function getValue<T>: T; overload;
+//  function getValue<T>: T; overload;
+  function getValue<T>(APropertyName: String = ''): T; overload;
   procedure Inject<T>(aValue: T); overload;
   procedure Inject<T>(aDelegate: TInjectNameDelegate<T>); overload;
   procedure Inject<T>(aPropertyName: String; aDelegate: TInjectDelegate<T>); overload;
@@ -375,12 +376,12 @@ begin
   end;
 end;
 
-function TAutoFixture.getValue<T>(): T;
+function TAutoFixture.getValue<T>(APropertyName: String): T;
 var ctx: TRttiContext;
   vValue: TValue;
 begin
   ctx := TRttiContext.Create;
-  vValue := getValue('', ctx.getType(TypeInfo(T)));
+  vValue := getValue(APropertyName, ctx.getType(TypeInfo(T)));
 
   if vValue.isEmpty then begin
     Result := Default(T);
@@ -389,6 +390,21 @@ begin
     Result := vValue.AsType<T>;
   end;
 end;
+
+//function TAutoFixture.getValue<T>(): T;
+//var ctx: TRttiContext;
+//  vValue: TValue;
+//begin
+//  ctx := TRttiContext.Create;
+//  vValue := getValue('', ctx.getType(TypeInfo(T)));
+//
+//  if vValue.isEmpty then begin
+//    Result := Default(T);
+//  end
+//  else begin
+//    Result := vValue.AsType<T>;
+//  end;
+//end;
 
 function TAutoFixture.NewInterface<T>: T;
 begin

--- a/AutoFixture.pas
+++ b/AutoFixture.pas
@@ -53,10 +53,9 @@ public
   function NewList<T: Class>(AReferenceDepth: Integer; AOwnsObjects: Boolean = True): TObjectList<T>; overload;
   function NewInterfaceList<T: IInterface>: TList<T>; overload;
   function NewInterfaceList<T: IInterface>(AReferenceDepth: Integer): TList<T>; overload;
+  function NewValue<T>(APropertyName: String = ''): T; overload;
+  function NewValueList<T>(APropertyName: String = ''): TList<T>;
 
-  function getValue(aPropertyName: String; aType: TRttiType): TValue; overload;
-//  function getValue<T>: T; overload;
-  function getValue<T>(APropertyName: String = ''): T; overload;
   procedure Inject<T>(aValue: T); overload;
   procedure Inject<T>(aDelegate: TInjectNameDelegate<T>); overload;
   procedure Inject<T>(aPropertyName: String; aDelegate: TInjectDelegate<T>); overload;
@@ -67,8 +66,10 @@ public
   function Configure<T: Class>: TBaseConfig<T>;
   function Build<T: Class>: TBaseConfig<T>;
 
+  function getValue(aPropertyName: String; aType: TRttiType): TValue; overload;
   function getObject(AType: TRttiType): TObject; overload;
   function getObject(AType: TRttiType; AReferenceDepth: Integer): TObject; Overload;
+
   procedure CallMethod(AOnObject: TObject; vMethod: TRttiMethod);
   function RegisterType<T, TBind>: TTypeList;
   function ResolveType(ARttiType: TRttiType): TRttiType;
@@ -376,7 +377,7 @@ begin
   end;
 end;
 
-function TAutoFixture.getValue<T>(APropertyName: String): T;
+function TAutoFixture.NewValue<T>(APropertyName: String): T;
 var ctx: TRttiContext;
   vValue: TValue;
 begin
@@ -390,21 +391,6 @@ begin
     Result := vValue.AsType<T>;
   end;
 end;
-
-//function TAutoFixture.getValue<T>(): T;
-//var ctx: TRttiContext;
-//  vValue: TValue;
-//begin
-//  ctx := TRttiContext.Create;
-//  vValue := getValue('', ctx.getType(TypeInfo(T)));
-//
-//  if vValue.isEmpty then begin
-//    Result := Default(T);
-//  end
-//  else begin
-//    Result := vValue.AsType<T>;
-//  end;
-//end;
 
 function TAutoFixture.NewInterface<T>: T;
 begin
@@ -446,6 +432,17 @@ begin
 
   ctx.Free;
 end;
+
+function TAutoFixture.NewValueList<T>(APropertyName: String): TList<T>;
+var
+  i: Integer;
+begin
+  Result := TList<T>.Create;
+  for i := 1 to Fsetup.CollectionSize do begin
+    Result.Add(NewValue<T>(APropertyName));
+  end;
+end;
+
 
 function TAutoFixture.NewInterfaceList<T>: TList<T>;
 var

--- a/AutoFixtureLibrary.pas
+++ b/AutoFixtureLibrary.pas
@@ -1,0 +1,93 @@
+unit AutoFixtureLibrary;
+
+interface
+
+uses
+  RTTI,
+  AutoFixtureSetup;
+
+type
+  TAutofixtureLibrary = class
+    class procedure GetMethods(ASetup: TAutofixtureSetup; AType: TRttiType; var vConstructor: TRttiMethod; var vAddMethod: TRttiMethod);
+  end;
+
+implementation
+
+{ TAutofixtureLibrary }
+
+class procedure TAutofixtureLibrary.GetMethods(ASetup: TAutofixtureSetup; AType: TRttiType; var vConstructor, vAddMethod: TRttiMethod);
+var
+  vMethod: TRttiMethod;
+begin
+  vConstructor := nil;
+  vAddMethod := nil;
+  if ASetup.ConstructorSearch = TConstructorSearch.csSimplest then begin
+    // Find simplest constructor deklareret i klassen
+    for vMethod in AType.GetMethods do begin
+      if vMethod.IsConstructor then begin
+        if Assigned(vConstructor) then begin
+          // don't shift to parent class constructor once class constructor found
+          if vMethod.Parent = AType then begin
+            if vConstructor.Parent = AType then begin
+              if Length(vMethod.GetParameters) < Length(vConstructor.GetParameters) then begin
+                vConstructor := vMethod;
+              end;
+            end
+            else begin
+              vConstructor := vMethod;
+            end;
+          end
+          else begin
+            if vConstructor.Parent <> AType then begin
+              if Length(vMethod.GetParameters) < Length(vConstructor.GetParameters) then begin
+                vConstructor := vMethod;
+              end;
+            end;
+          end;
+        end
+        else begin
+          vConstructor := vMethod;
+        end;
+      end
+      else if vMethod.Name = 'Add' then begin
+        if Assigned(vAddMethod) then begin
+          if (vMethod.Parent = AType) and (vAddMethod.Parent <> AType) then begin
+            vAddMethod := vMethod;
+          end;
+        end
+        else begin
+          vAddMethod := vMethod;
+        end;
+      end;
+    end;
+  end
+  else if ASetup.ConstructorSearch = TConstructorSearch.csMostParams then begin
+    // Find constructor with many params
+    for vMethod in AType.GetDeclaredMethods do begin
+      if vMethod.IsConstructor then begin
+        if Assigned(vConstructor) then begin
+          if Length(vMethod.GetParameters) > Length(vConstructor.GetParameters) then begin
+            vConstructor := vMethod;
+          end;
+        end
+        else begin
+          vConstructor := vMethod;
+        end;
+      end
+      else if vMethod.Name = 'Add' then begin
+        vAddMethod := vMethod;
+      end;
+    end;
+  end
+  else begin
+    // Find only add method
+    for vMethod in AType.GetDeclaredMethods do begin
+      if vMethod.Name = 'Add' then begin
+        vAddMethod := vMethod;
+      end;
+    end;
+  end;
+end;
+
+
+end.

--- a/AutoFixtureProject.dpr
+++ b/AutoFixtureProject.dpr
@@ -1,5 +1,5 @@
 program AutoFixtureProject;
-
+{$M+}
 {$IFNDEF TESTINSIGHT}
 {$APPTYPE CONSOLE}
 {$ENDIF}{$STRONGLINKTYPES ON}
@@ -26,7 +26,8 @@ uses
   Test.AutoFixture.Configure in 'Test\Test.AutoFixture.Configure.pas',
   Test.AutoFixture.Build in 'Test\Test.AutoFixture.Build.pas',
   Test.Autofixture.exceptions in 'Test\Test.Autofixture.exceptions.pas',
-  Test.Autofixture.Setup in 'Test\Test.Autofixture.Setup.pas';
+  Test.Autofixture.Setup in 'Test\Test.Autofixture.Setup.pas',
+  AutoFixtureLibrary in 'AutoFixtureLibrary.pas';
 
 var
   runner : ITestRunner;

--- a/AutoFixtureProject.dpr
+++ b/AutoFixtureProject.dpr
@@ -25,7 +25,8 @@ uses
   Test.AutoFixture.Types in 'Test\Test.AutoFixture.Types.pas',
   Test.AutoFixture.Configure in 'Test\Test.AutoFixture.Configure.pas',
   Test.AutoFixture.Build in 'Test\Test.AutoFixture.Build.pas',
-  Test.Autofixture.exceptions in 'Test\Test.Autofixture.exceptions.pas';
+  Test.Autofixture.exceptions in 'Test\Test.Autofixture.exceptions.pas',
+  Test.Autofixture.Setup in 'Test\Test.Autofixture.Setup.pas';
 
 var
   runner : ITestRunner;

--- a/AutoFixtureProject.dproj
+++ b/AutoFixtureProject.dproj
@@ -69,7 +69,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
         <DCC_Inlining>off</DCC_Inlining>
-        <DCC_DebugDCUs>false</DCC_DebugDCUs>
         <DCC_MapFile>3</DCC_MapFile>
         <DCC_LegacyIFEND>true</DCC_LegacyIFEND>
         <DCC_OutputDependencies>true</DCC_OutputDependencies>
@@ -181,6 +180,7 @@
         <DCCReference Include="Test\Test.AutoFixture.Build.pas"/>
         <DCCReference Include="Test\Test.Autofixture.exceptions.pas"/>
         <DCCReference Include="Test\Test.Autofixture.Setup.pas"/>
+        <DCCReference Include="AutoFixtureLibrary.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/AutoFixtureProject.dproj
+++ b/AutoFixtureProject.dproj
@@ -148,7 +148,7 @@
         <DCC_XML_WHITESPACE_NOT_ALLOWED>error</DCC_XML_WHITESPACE_NOT_ALLOWED>
         <DCC_IMMUTABLE_STRINGS>true</DCC_IMMUTABLE_STRINGS>
         <DCC_EXPLICIT_STRING_CAST_LOSS>error</DCC_EXPLICIT_STRING_CAST_LOSS>
-        <DCC_UNSAFE_CAST>true</DCC_UNSAFE_CAST>
+        <DCC_UNSAFE_CAST>error</DCC_UNSAFE_CAST>
         <DCC_UNSAFE_TYPE>error</DCC_UNSAFE_TYPE>
         <DCC_EXPLICIT_STRING_CAST>true</DCC_EXPLICIT_STRING_CAST>
         <VerInfo_Locale>1033</VerInfo_Locale>
@@ -180,6 +180,7 @@
         <DCCReference Include="Test\Test.AutoFixture.Configure.pas"/>
         <DCCReference Include="Test\Test.AutoFixture.Build.pas"/>
         <DCCReference Include="Test\Test.Autofixture.exceptions.pas"/>
+        <DCCReference Include="Test\Test.Autofixture.Setup.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Examples/ClassesToTest.pas
+++ b/Examples/ClassesToTest.pas
@@ -12,6 +12,7 @@ uses
 type
 
 // CLASSES CONTAINING TEST DATA (Not code classes)
+{$M+} // Ensure RTTI information is turned on
 TSteeringWheel = class
 protected
   FDirectionAngle: Double;

--- a/Test/Test.AutoFixture.Build.pas
+++ b/Test/Test.AutoFixture.Build.pas
@@ -299,4 +299,7 @@ begin
   Assert.AreEqual(AValue, vTest.FExtended, 'Build Extended');
 end;
 
+initialization
+  TDUnitX.RegisterTestFixture(TAutofixtureBuildTest);
+
 end.

--- a/Test/Test.AutoFixture.Configure.pas
+++ b/Test/Test.AutoFixture.Configure.pas
@@ -410,4 +410,7 @@ begin
   Assert.AreEqual(AValue, vTest.FExtended, 'Configure Extended');
 end;
 
+initialization
+  TDUnitX.RegisterTestFixture(TAutofixtureConfigureTest);
+
 end.

--- a/Test/Test.AutoFixture.Configure.pas
+++ b/Test/Test.AutoFixture.Configure.pas
@@ -199,8 +199,8 @@ var
   vRec: TRecord;
 begin
   // Arrange
-  vRec.FString := UUT.NewValue<string>;
-  vRec.FInt := UUT.NewValue<integer>;
+  vRec.FString := UUT.New<string>;
+  vRec.FInt := UUT.New<integer>;
 
   UUT.Configure<TTestSubClass>.WithValue<TRecord>(
     function (ATestSubClass: TTestSubClass): TRecord

--- a/Test/Test.AutoFixture.Configure.pas
+++ b/Test/Test.AutoFixture.Configure.pas
@@ -199,8 +199,8 @@ var
   vRec: TRecord;
 begin
   // Arrange
-  vRec.FString := UUT.GetValue<string>;
-  vRec.FInt := UUT.GetValue<integer>;
+  vRec.FString := UUT.NewValue<string>;
+  vRec.FInt := UUT.NewValue<integer>;
 
   UUT.Configure<TTestSubClass>.WithValue<TRecord>(
     function (ATestSubClass: TTestSubClass): TRecord

--- a/Test/Test.AutoFixture.Types.pas
+++ b/Test/Test.AutoFixture.Types.pas
@@ -24,6 +24,8 @@ end;
 TTestAbstractClass = class(TInterfacedObject, ITestInterfaceType)
 public
   FProperty: String;
+
+  constructor Create; virtual;
 end;
 
 TTestSubClass = class(TTestAbstractClass, ITestInterfaceType)
@@ -46,5 +48,12 @@ public
 end;
 
 implementation
+
+{ TTestAbstractClass }
+
+constructor TTestAbstractClass.Create;
+begin
+  Self.FProperty := 'TEST';
+end;
 
 end.

--- a/Test/Test.AutoFixture.pas
+++ b/Test/Test.AutoFixture.pas
@@ -33,6 +33,9 @@ public
 
     [Test]
     procedure TestList;
+
+    [Test]
+    procedure TestValueString;
 end;
 
 
@@ -115,6 +118,16 @@ begin
   // Assert
   Assert.IsTrue(vResult is TTestSubClass);
   Assert.AreNotEqual('', vResult.FSubProperty, 'Properties must have been initialized');
+end;
+
+procedure TAutofixtureTest.TestValueString;
+var s: String;
+begin
+  // Act
+  s := UUT.getValue<String>('Name');
+
+  // Assert
+  Assert.AreNotEqual('', s, 'String generation');
 end;
 
 end.

--- a/Test/Test.AutoFixture.pas
+++ b/Test/Test.AutoFixture.pas
@@ -36,6 +36,12 @@ public
 
     [Test]
     procedure TestValueString;
+
+    [Test]
+    procedure TestInjectString;
+
+    [Test]
+    procedure TestInjectDelegate;
 end;
 
 
@@ -73,6 +79,46 @@ begin
   // Assert
   Assert.IsTrue(vResult is TTestSubClass);
   Assert.AreNotEqual('', vResult.FSubProperty, 'Properties must have been initialized');
+end;
+
+procedure TAutofixtureTest.TestInjectString;
+var
+  s: String;
+begin
+  // Arrange
+  UUT.Inject<String>('Ploeh');
+
+  // Act
+  s := UUT.NewValue<String>;
+
+  // Assert
+  Assert.AreEqual('Ploeh', s, 'String inject');
+end;
+
+procedure TAutofixtureTest.TestInjectDelegate;
+var
+  str1, str2: String;
+begin
+  // Arrange
+  UUT.Inject<String>(
+    function (APropertyName: String): String
+    begin
+      if APropertyName.ToUpper.Contains('NAME') then begin
+        Result := 'Mark Seemann';
+      end
+      else begin
+        Result := 'Unknown';
+      end;
+    end
+  );
+
+  // Act
+  str1 := UUT.NewValue<String>('AnythingElse');
+  str2 := UUT.NewValue<String>('MyName');
+
+  // Assert
+  Assert.AreNotEqual('Mark Seemann', str1, 'String delegate');
+  Assert.AreEqual('Mark Seemann', str2, 'String delegate');
 end;
 
 procedure TAutofixtureTest.TestInterfaceBinding;
@@ -124,7 +170,7 @@ procedure TAutofixtureTest.TestValueString;
 var s: String;
 begin
   // Act
-  s := UUT.getValue<String>('Name');
+  s := UUT.NewValue<String>('Name');
 
   // Assert
   Assert.AreNotEqual('', s, 'String generation');

--- a/Test/Test.AutoFixture.pas
+++ b/Test/Test.AutoFixture.pas
@@ -42,15 +42,79 @@ public
 
     [Test]
     procedure TestInjectDelegate;
+
+    [Test]
+    procedure TestObjectConstructor;
+
+    [Test]
+    procedure AddToArray;
+
+    [Test]
+    procedure AddToTList;
+
+    [Test]
+    procedure AddToObjectList;
+
+    [Test]
+    procedure AddToCollection;
 end;
 
 
 
 implementation
 
-uses SysUtils;
+uses SysUtils,
+  System.Classes,
+  AutofixtureSetup;
 
 { TAutofixtureTest }
+
+procedure TAutofixtureTest.AddToArray;
+var vArray: TArray<Integer>;
+begin
+  // Arrange
+  // Act
+  UUT.AddManyToArray<Integer>(vArray);
+
+  // Assert
+  Assert.AreEqual(UUT.Setup.CollectionSize, Length(vArray), 'TArray<Integer> length');
+end;
+
+procedure TAutofixtureTest.AddToCollection;
+var vCol: TCollection;
+begin
+  // Arrange
+  //UUT.Setup.ConstructorSearch := TConstructorSearch.csNone;
+  //vCol := TCollection.Create;
+
+  vCol := UUT.New<TCollection>;
+  // Act
+  UUT.AddManyTo(vCol);
+  // Assert
+  Assert.AreEqual(UUT.Setup.CollectionSize * 2, vCol.Count, 'TCollection Size');
+end;
+
+procedure TAutofixtureTest.AddToObjectList;
+var vList: TObjectList<TTestAbstractClass>;
+begin
+  // Arrange
+  vList := UUT.NewObjectList<TTestAbstractClass>;
+  // Act
+  UUT.AddManyTo(vList);
+  // Assert
+  Assert.AreEqual(UUT.Setup.CollectionSize * 2, vList.Count, 'TObjectList Size');
+end;
+
+procedure TAutofixtureTest.AddToTList;
+var vList: TList<Integer>;
+begin
+  // Arrange
+  vList := UUT.NewList<Integer>;
+  // Act
+  UUT.AddManyTo(vList);
+  // Assert
+  Assert.AreEqual(UUT.Setup.CollectionSize * 2, vList.Count, 'TList Size');
+end;
 
 procedure TAutofixtureTest.Setup;
 begin
@@ -89,7 +153,7 @@ begin
   UUT.Inject<String>('Ploeh');
 
   // Act
-  s := UUT.NewValue<String>;
+  s := UUT.New<String>;
 
   // Assert
   Assert.AreEqual('Ploeh', s, 'String inject');
@@ -113,8 +177,8 @@ begin
   );
 
   // Act
-  str1 := UUT.NewValue<String>('AnythingElse');
-  str2 := UUT.NewValue<String>('MyName');
+  str1 := UUT.New<String>('AnythingElse');
+  str2 := UUT.New<String>('MyName');
 
   // Assert
   Assert.AreNotEqual('Mark Seemann', str1, 'String delegate');
@@ -130,7 +194,7 @@ begin
   UUT.RegisterType<TTestAbstractClass, TTestSubClass>;
 
   // Act
-  vIObj := UUT.NewInterface<ITestInterfaceType>;
+  vIObj := UUT.New<ITestInterfaceType>;
 
   // Assert
   Assert.IsTrue(vIObj is TTestSubClass);
@@ -146,10 +210,22 @@ begin
   UUT.RegisterType<ITestInterfaceType, TTestAbstractClass>;
   UUT.RegisterType<TTestAbstractClass, TTestSubClass>;
   // Act
-  vIObj := UUT.NewInterface<ITestInterfaceType>;
+  vIObj := UUT.New<ITestInterfaceType>;
 
   // Assert
   Assert.AreEqual(1,1)
+end;
+
+procedure TAutofixtureTest.TestObjectConstructor;
+var
+  vRes: TTestAbstractClass;
+begin
+  // Act
+  vRes := UUT.Build<TTestAbstractClass>.OmitAutoProperties.New;
+  vRes := TTestAbstractClass.Create;
+
+  // Assert
+  Assert.AreEqual('TEST', vRes.FProperty, 'Constructor call');
 end;
 
 procedure TAutofixtureTest.TestObjectInitialization;
@@ -170,7 +246,7 @@ procedure TAutofixtureTest.TestValueString;
 var s: String;
 begin
   // Act
-  s := UUT.NewValue<String>('Name');
+  s := UUT.New<String>('Name');
 
   // Assert
   Assert.AreNotEqual('', s, 'String generation');

--- a/Test/Test.AutoFixture.pas
+++ b/Test/Test.AutoFixture.pas
@@ -198,7 +198,7 @@ begin
 
   // Assert
   Assert.IsTrue(vIObj is TTestSubClass);
-  Assert.AreNotEqual('', TTestSubClass(vIObj).FSubProperty, 'Properties must have been initialized');
+  Assert.AreNotEqual('', TTestSubClass(vIObj).FSubProperty, 'Properties initialized');
   Assert.AreEqual(TTestSubClass(vIObj).FList.Count, UUT.Setup.CollectionSize, 'List initialized with correct size');
 end;
 
@@ -222,7 +222,6 @@ var
 begin
   // Act
   vRes := UUT.Build<TTestAbstractClass>.OmitAutoProperties.New;
-  vRes := TTestAbstractClass.Create;
 
   // Assert
   Assert.AreEqual('TEST', vRes.FProperty, 'Constructor call');
@@ -251,5 +250,8 @@ begin
   // Assert
   Assert.AreNotEqual('', s, 'String generation');
 end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TAutofixtureTest);
 
 end.

--- a/Test/Test.Autofixture.Setup.pas
+++ b/Test/Test.Autofixture.Setup.pas
@@ -38,6 +38,8 @@ end;
 
 TTestReferenceDepth = class;
 
+// TTestReferenceDepthList = TList<TTestReferenceDepth>;
+
 TTestReferenceDepth = class(TCollectionItem)
 public
   FParent: TTestReferenceDepth;
@@ -46,7 +48,7 @@ public
 end;
 
 // Setup class reference for binding
-TCollectionItemClass = class of TCollectionItem;
+//TCollectionItemClass = class of TCollectionItem; // Use the one from Classes, otherwise there will be two differing types
 TTestReferenceDepthClass = class of TTestReferenceDepth;
 
 implementation
@@ -72,8 +74,9 @@ begin
   // Arrange
   UUT.Setup.ReferenceDepth := ADepth;
   // Because TTestReferenceDepth inherits from collectionItem, there are properties that should not be set
-  UUT.Configure<TTestReferenceDepth>.Omit<Integer>('Index'); // Don't try to set a value for index
-  UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('Collection'); // Don't try to set a value for Collection
+  //UUT.Configure<TTestReferenceDepth>.Omit<Integer>('Index'); // Don't try to set a value for index
+  //UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('Collection'); // Don't try to set a value for Collection
+  UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('FCollection'); // Optimization, not needed for this test
   // Act
   vTestDepth := UUT.New<TTestReferenceDepth>;
   // Assert
@@ -110,8 +113,10 @@ begin
   UUT.Setup.ReferenceDepth := ADepth;
   UUT.RegisterType<TCollectionItemClass, TTestReferenceDepthClass>; // This initializes the TCollection to contain TTestReferenceDepth instances
   // Because TTestReferenceDepth inherits from collectionItem, there are properties that should not be set
-  UUT.Configure<TTestReferenceDepth>.Omit<Integer>('Index'); // Don't try to set a value for index
-  UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('Collection'); // Don't try to set a value for Collection
+  //UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('Index'); // Don't try to set a value for index
+  //UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('Collection'); // Don't try to set a value for Collection
+  UUT.Configure<TTestReferenceDepth>.Omit<TList<TTestReferenceDepth>>('FList'); // only interested in the collection for this testcase
+  UUT.Configure<TTestReferenceDepth>.Omit<TTestReferenceDepth>('FParent'); // only interested in the collection for this testcase
   // Act
   vTestDepth := UUT.New<TTestReferenceDepth>;
   // Assert
@@ -130,5 +135,8 @@ begin
   end;
   Assert.AreEqual(ADepth, vDepth, 'List depth');
 end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TAutofixtureSetupTest);
 
 end.

--- a/Test/Test.Autofixture.Setup.pas
+++ b/Test/Test.Autofixture.Setup.pas
@@ -1,0 +1,134 @@
+unit Test.Autofixture.Setup;
+
+interface
+uses AutoFixture,
+  DUnitX.TestFramework,
+  Generics.Collections,
+  Test.AutoFixture.Types,
+  System.Classes;
+
+type
+
+[TestFixture]
+TAutofixtureSetupTest = class
+private
+  UUT: TAutoFixture;
+public
+    [SetUp]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    [TestCase('Hierarchy depth 0', '0')]
+    [TestCase('Hierarchy depth 1', '1')]
+    [TestCase('Hierarchy depth 2', '2')]
+    [TestCase('Hierarchy depth 3', '3')]
+    [TestCase('Hierarchy depth 4', '4')]
+    procedure TestReferenceDepth(ADepth: Integer);
+
+    [Test]
+    [TestCase('Hierarchy depth 0', '0')]
+    [TestCase('Hierarchy depth 1', '1')]
+    [TestCase('Hierarchy depth 2', '2')]
+    [TestCase('Hierarchy depth 3', '3')]
+    [TestCase('Hierarchy depth 4', '4')]
+    procedure TestReferenceDepthForCollection(ADepth: Integer);
+end;
+
+TTestReferenceDepth = class;
+
+TTestReferenceDepth = class(TCollectionItem)
+public
+  FParent: TTestReferenceDepth;
+  FList: TList<TTestReferenceDepth>;
+  FCollection: TCollection;
+end;
+
+// Setup class reference for binding
+TCollectionItemClass = class of TCollectionItem;
+TTestReferenceDepthClass = class of TTestReferenceDepth;
+
+implementation
+
+uses SysUtils,
+  AutofixtureSetup;
+
+procedure TAutofixtureSetupTest.Setup;
+begin
+  UUT := TAutoFixture.Create;
+end;
+
+procedure TAutofixtureSetupTest.TearDown;
+begin
+  FreeAndNil(UUT);
+end;
+
+procedure TAutofixtureSetupTest.TestReferenceDepth(ADepth: Integer);
+var
+  vTestDepth, vIterator: TTestReferenceDepth;
+  vDepth: Integer;
+begin
+  // Arrange
+  UUT.Setup.ReferenceDepth := ADepth;
+  // Because TTestReferenceDepth inherits from collectionItem, there are properties that should not be set
+  UUT.Configure<TTestReferenceDepth>.Omit<Integer>('Index'); // Don't try to set a value for index
+  UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('Collection'); // Don't try to set a value for Collection
+  // Act
+  vTestDepth := UUT.New<TTestReferenceDepth>;
+  // Assert
+    // Find parent depth
+    vIterator := vTestDepth;
+    vDepth := 0;
+    while Assigned(vIterator) do begin
+      inc(vDepth, 1);
+      vIterator := vIterator.FParent;
+    end;
+    Assert.AreEqual(ADepth, vDepth, 'Parent depth');
+
+    // Find list depth
+    vIterator := vTestDepth;
+    vDepth := 0;
+    while Assigned(vIterator) do begin
+      inc(vDepth, 1);
+      if Assigned(vIterator.FList) and (vIterator.FList.Count > 0) then begin
+        vIterator := vIterator.FList[0];
+      end
+      else begin
+        vIterator := nil;
+      end;
+    end;
+    Assert.AreEqual(ADepth, vDepth, 'List depth');
+end;
+
+procedure TAutofixtureSetupTest.TestReferenceDepthForCollection(ADepth: Integer);
+var
+  vTestDepth, vIterator: TTestReferenceDepth;
+  vDepth: Integer;
+begin
+  // Arrange
+  UUT.Setup.ReferenceDepth := ADepth;
+  UUT.RegisterType<TCollectionItemClass, TTestReferenceDepthClass>; // This initializes the TCollection to contain TTestReferenceDepth instances
+  // Because TTestReferenceDepth inherits from collectionItem, there are properties that should not be set
+  UUT.Configure<TTestReferenceDepth>.Omit<Integer>('Index'); // Don't try to set a value for index
+  UUT.Configure<TTestReferenceDepth>.Omit<TCollection>('Collection'); // Don't try to set a value for Collection
+  // Act
+  vTestDepth := UUT.New<TTestReferenceDepth>;
+  // Assert
+
+  // Find Collection depth
+  vIterator := vTestDepth;
+  vDepth := 0;
+  while Assigned(vIterator) do begin
+    inc(vDepth, 1);
+    if Assigned(vIterator.FCollection) and (vIterator.FCollection.Count > 0) then begin
+      vIterator := vIterator.FCollection.Items[0] as TTestReferenceDepth;
+    end
+    else begin
+      vIterator := nil;
+    end;
+  end;
+  Assert.AreEqual(ADepth, vDepth, 'List depth');
+end;
+
+end.

--- a/Test/Test.Autofixture.exceptions.pas
+++ b/Test/Test.Autofixture.exceptions.pas
@@ -42,7 +42,6 @@ end;
 
 procedure TAutofixtureExceptionTest.TestLargeSet;
 var
-  vTest: TTestSubClass;
   vExpected: TWeekSet;
 begin
   // Arrange
@@ -63,7 +62,6 @@ end;
 
 procedure TAutofixtureExceptionTest.TestLargeSetByName;
 var
-  vTest: TTestSubClass;
   vExpected: TWeekSet;
 begin
   // Arrange
@@ -77,5 +75,8 @@ begin
     end,
     Exception, 'Autofixture is unable to get RTTI type information for this type', 'Type error');
 end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TAutofixtureExceptionTest);
 
 end.

--- a/Test/Test.RandomGeneratorTest.pas
+++ b/Test/Test.RandomGeneratorTest.pas
@@ -392,4 +392,7 @@ begin
   Assert.IsTrue(vValue.AsType<Word>() > 0, 'Der kan genereres en Word');
 end;
 
+initialization
+  TDUnitX.RegisterTestFixture(TRandomGeneratorTest);
+
 end.


### PR DESCRIPTION
Primarily this feature change was to implement the AddManyTo functionality found in the .Net version.
This caused some problems regarding the TCollection type, since this type insists it should be the one to generate the objects, and not autofixture.
This caused som refactoring of the Autofixture internals
Which in turn meant that I discovered the Spring4d Class helper for TValue, which meant I could simplify the autofixture interface even more, and bring it even closer to the .Net original.

This means that TAutofixture.New<T> can now be used to generate simple types as well as objects or even interface based objects